### PR TITLE
Improves Store Loading

### DIFF
--- a/src/main/java/tech/blacksource/blacknectar/service/data/SQL.java
+++ b/src/main/java/tech/blacksource/blacknectar/service/data/SQL.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 BlackSource, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tech.blacksource.blacknectar.service.data;
+
+import com.google.common.base.Objects;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tech.sirwellington.alchemy.annotations.access.Internal;
+import tech.sirwellington.alchemy.annotations.access.NonInstantiable;
+
+/**
+ *
+ * @author SirWellington
+ */
+@Internal
+@NonInstantiable
+final class SQL
+{
+
+    private final static Logger LOG = LoggerFactory.getLogger(SQL.class);
+
+    /**
+     * Determines whether a {@link ResultSet} has a column present.
+     * 
+     * @param results
+     * @param expectedColumn
+     * @return
+     * @throws SQLException 
+     */
+    static boolean hasColumn(ResultSet results, String expectedColumn) throws SQLException
+    {
+        ResultSetMetaData metadata = results.getMetaData();
+
+        for (int i = 1; i <= metadata.getColumnCount(); ++i)
+        {
+            String columnName = metadata.getColumnLabel(i);
+
+            if (Objects.equal(columnName, expectedColumn))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/tech/blacksource/blacknectar/service/data/SQLImageMapper.java
+++ b/src/main/java/tech/blacksource/blacknectar/service/data/SQLImageMapper.java
@@ -22,6 +22,7 @@ import java.sql.ResultSet;
 import java.sql.SQLDataException;
 import java.sql.SQLException;
 import java.util.UUID;
+import javax.inject.Inject;
 import org.springframework.jdbc.core.RowMapper;
 import tech.blacksource.blacknectar.service.images.Image;
 
@@ -52,6 +53,16 @@ public interface SQLImageMapper extends RowMapper<Image>
 
     static class Impl implements SQLImageMapper
     {
+
+        private final SQLTools sqlTools;
+
+        @Inject
+        Impl(SQLTools sqlTools)
+        {
+            checkThat(sqlTools).is(notNull());
+            
+            this.sqlTools = sqlTools;
+        }
 
         @Override
         public Image mapRow(ResultSet results, int rowNum) throws SQLException
@@ -120,8 +131,8 @@ public interface SQLImageMapper extends RowMapper<Image>
                     throw new SQLDataException("could not convert to URL: " + url, ex);
                 }
             }
-            
-            if (SQL.hasColumn(results, SQLColumns.Images.IMAGE_BINARY))
+
+            if (sqlTools.hasColumn(results, SQLColumns.Images.IMAGE_BINARY))
             {
                 byte[] binary = results.getBytes(SQLColumns.Images.IMAGE_BINARY);
 
@@ -133,7 +144,6 @@ public interface SQLImageMapper extends RowMapper<Image>
 
             return builder.build();
         }
-        
 
     }
 

--- a/src/main/java/tech/blacksource/blacknectar/service/data/SQLImageMapper.java
+++ b/src/main/java/tech/blacksource/blacknectar/service/data/SQLImageMapper.java
@@ -16,11 +16,9 @@
 
 package tech.blacksource.blacknectar.service.data;
 
-import com.google.common.base.Objects;
 import com.google.inject.ImplementedBy;
 import java.net.MalformedURLException;
 import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
 import java.sql.SQLDataException;
 import java.sql.SQLException;
 import java.util.UUID;
@@ -123,7 +121,7 @@ public interface SQLImageMapper extends RowMapper<Image>
                 }
             }
             
-            if (hasColumn(results, SQLColumns.Images.IMAGE_BINARY))
+            if (SQL.hasColumn(results, SQLColumns.Images.IMAGE_BINARY))
             {
                 byte[] binary = results.getBytes(SQLColumns.Images.IMAGE_BINARY);
 
@@ -135,24 +133,6 @@ public interface SQLImageMapper extends RowMapper<Image>
 
             return builder.build();
         }
-
-        private boolean hasColumn(ResultSet results, String expectedColumn) throws SQLException
-        {
-            ResultSetMetaData metadata = results.getMetaData();
-            
-            for (int i = 1; i <= metadata.getColumnCount(); ++i)
-            {
-                String columnName = metadata.getColumnLabel(i);
-                
-                if (Objects.equal(columnName, expectedColumn))
-                {
-                    return true;
-                }
-            }
-            
-            return false;
-        }
-        
         
 
     }

--- a/src/main/java/tech/blacksource/blacknectar/service/data/SQLTools.java
+++ b/src/main/java/tech/blacksource/blacknectar/service/data/SQLTools.java
@@ -26,6 +26,10 @@ import org.slf4j.LoggerFactory;
 import tech.blacksource.blacknectar.service.data.SQLImageMapper.Impl;
 import tech.sirwellington.alchemy.annotations.access.Internal;
 
+import static tech.sirwellington.alchemy.arguments.Arguments.checkThat;
+import static tech.sirwellington.alchemy.arguments.assertions.Assertions.notNull;
+import static tech.sirwellington.alchemy.arguments.assertions.StringAssertions.nonEmptyString;
+
 /**
  * Tools used in conjunction with JDBC.
  *
@@ -54,6 +58,9 @@ interface SQLTools
         @Override
         public boolean hasColumn(ResultSet results, String expectedColumn) throws SQLException
         {
+            checkThat(results).is(notNull());
+            checkThat(expectedColumn).is(nonEmptyString());
+            
             ResultSetMetaData metadata = results.getMetaData();
 
             for (int i = 1; i <= metadata.getColumnCount(); ++i)

--- a/src/main/java/tech/blacksource/blacknectar/service/data/SQLTools.java
+++ b/src/main/java/tech/blacksource/blacknectar/service/data/SQLTools.java
@@ -23,7 +23,6 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import tech.blacksource.blacknectar.service.data.SQLImageMapper.Impl;
 import tech.sirwellington.alchemy.annotations.access.Internal;
 
 import static tech.sirwellington.alchemy.arguments.Arguments.checkThat;
@@ -36,7 +35,7 @@ import static tech.sirwellington.alchemy.arguments.assertions.StringAssertions.n
  * @author SirWellington
  */
 @Internal
-@ImplementedBy(Impl.class)
+@ImplementedBy(SQLTools.Impl.class)
 interface SQLTools
 {
 

--- a/src/main/java/tech/blacksource/blacknectar/service/data/SQLTools.java
+++ b/src/main/java/tech/blacksource/blacknectar/service/data/SQLTools.java
@@ -17,47 +17,58 @@
 package tech.blacksource.blacknectar.service.data;
 
 import com.google.common.base.Objects;
+import com.google.inject.ImplementedBy;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tech.blacksource.blacknectar.service.data.SQLImageMapper.Impl;
 import tech.sirwellington.alchemy.annotations.access.Internal;
-import tech.sirwellington.alchemy.annotations.access.NonInstantiable;
 
 /**
+ * Tools used in conjunction with JDBC.
  *
  * @author SirWellington
  */
 @Internal
-@NonInstantiable
-final class SQL
+@ImplementedBy(Impl.class)
+interface SQLTools
 {
-
-    private final static Logger LOG = LoggerFactory.getLogger(SQL.class);
 
     /**
      * Determines whether a {@link ResultSet} has a column present.
-     * 
+     *
      * @param results
      * @param expectedColumn
      * @return
-     * @throws SQLException 
+     * @throws SQLException
      */
-    static boolean hasColumn(ResultSet results, String expectedColumn) throws SQLException
+    boolean hasColumn(ResultSet results, String expectedColumn) throws SQLException;
+
+    class Impl implements SQLTools
     {
-        ResultSetMetaData metadata = results.getMetaData();
 
-        for (int i = 1; i <= metadata.getColumnCount(); ++i)
+        private final static Logger LOG = LoggerFactory.getLogger(Impl.class);
+
+        @Override
+        public boolean hasColumn(ResultSet results, String expectedColumn) throws SQLException
         {
-            String columnName = metadata.getColumnLabel(i);
+            ResultSetMetaData metadata = results.getMetaData();
 
-            if (Objects.equal(columnName, expectedColumn))
+            for (int i = 1; i <= metadata.getColumnCount(); ++i)
             {
-                return true;
+                String columnName = metadata.getColumnLabel(i);
+
+                if (Objects.equal(columnName, expectedColumn))
+                {
+                    return true;
+                }
             }
+
+            return false;
         }
 
-        return false;
     }
+
 }

--- a/src/main/java/tech/blacksource/blacknectar/service/data/StoreRepository.java
+++ b/src/main/java/tech/blacksource/blacknectar/service/data/StoreRepository.java
@@ -158,11 +158,11 @@ public interface StoreRepository
      * @param database The {@linkplain JdbcTemplate JDBC connection} , must be open.
      * 
      * @return
-     * 
-     * @throws SQLException 
+     *
+     * @throws SQLException
      */
     static StoreRepository newSQLService(@Required Aroma aroma,
-                                            @Required JdbcTemplate database) throws SQLException
+                                         @Required JdbcTemplate database) throws SQLException
     {
         return new SQLStoreRepository(aroma, database, SQLStoreMapper.INSTANCE);
     }

--- a/src/main/java/tech/blacksource/blacknectar/service/operations/SayHelloOperation.java
+++ b/src/main/java/tech/blacksource/blacknectar/service/operations/SayHelloOperation.java
@@ -18,7 +18,6 @@
 package tech.blacksource.blacknectar.service.operations;
 
 
-import com.google.common.base.Strings;
 import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,7 +67,7 @@ public class SayHelloOperation implements Route
         
         response.status(200);
         //U+1F573
-        return Strings.repeat("🌑", 1000);
+        return "We are BlackSource 🌑";
     }
 
 }

--- a/src/main/java/tech/blacksource/blacknectar/service/operations/SearchStoresOperation.java
+++ b/src/main/java/tech/blacksource/blacknectar/service/operations/SearchStoresOperation.java
@@ -109,8 +109,7 @@ public class SearchStoresOperation implements Route
 
         List<Store> stores = findStores(request);
 
-        JsonArray json = stores.parallelStream()
-            .map(this::tryToEnrichStoreWithImage)
+        JsonArray json = stores.stream()
             .map(Store::asJSON)
             .collect(JSON.collectArray());
 

--- a/src/main/java/tech/blacksource/blacknectar/service/stores/Store.java
+++ b/src/main/java/tech/blacksource/blacknectar/service/stores/Store.java
@@ -374,6 +374,12 @@ public class Store implements JSONRepresentable
             this.mainImageURL = imageURL;
             return this;
         }
+        
+        public Builder withoutMainImageURL() 
+        {
+            this.mainImageURL = null;
+            return this;
+        }
 
         public Store build() throws IllegalStateException
         {

--- a/src/main/resources/sql/postgresql/query_stores_with_location.sql
+++ b/src/main/resources/sql/postgresql/query_stores_with_location.sql
@@ -3,8 +3,10 @@
 -- ===========================================================================
 
 SELECT
-	*,
+	Stores.*,
+	Store_Images.url,
 	ST_Distance(location, ST_SetSRID(ST_Point(?, ?), 4326)::geography) AS distance_meters
 FROM Stores
+LEFT JOIN Store_Images USING(store_id)
 WHERE ST_DWithin(location, ST_SetSRID(ST_Point(?, ?), 4326)::geography, ?)
-ORDER BY distance_meters
+ORDER BY distance_meters ASC

--- a/src/main/resources/sql/postgresql/query_stores_with_name.sql
+++ b/src/main/resources/sql/postgresql/query_stores_with_name.sql
@@ -3,7 +3,9 @@
 -- ===========================================================================
 
 SELECT
-	*
+	Stores.*,
+	Store_Images.url
 FROM Stores
+LEFT JOIN Store_Images USING(store_id)
 WHERE store_name LIKE ?
 ORDER BY store_name

--- a/src/main/resources/sql/postgresql/query_stores_with_name_and_location.sql
+++ b/src/main/resources/sql/postgresql/query_stores_with_name_and_location.sql
@@ -3,9 +3,11 @@
 -- ===========================================================================
 
 SELECT
-	*,
+	Stores.*,
+	Store_Images.url,
 	ST_Distance(location, ST_SetSRID(ST_Point(?, ?), 4326)::geography) AS distance_meters
 FROM Stores
+LEFT JOIN Store_Images USING(store_id)
 WHERE store_name LIKE ?
 AND ST_DWithin(location, ST_SetSRID(ST_Point(?, ?), 4326)::geography, ?)
 ORDER BY distance_meters

--- a/src/test/java/tech/blacksource/blacknectar/service/BlackNectarGenerators.java
+++ b/src/test/java/tech/blacksource/blacknectar/service/BlackNectarGenerators.java
@@ -86,6 +86,7 @@ public class BlackNectarGenerators
                 .withAddress(addresses().get())
                 .withLocation(locations().get())
                 .withName(one(alphabeticString()))
+                .withMainImageURL(one(httpUrls()).toString())
                 .build(); 
         };
     }

--- a/src/test/java/tech/blacksource/blacknectar/service/TestingResources.java
+++ b/src/test/java/tech/blacksource/blacknectar/service/TestingResources.java
@@ -51,10 +51,10 @@ public class TestingResources
     {
         return INJECTOR.getInstance(Aroma.class);
     }
-
+    
     public static SQLImageMapper getImageMapper()
     {
-        return new SQLImageMapper.Impl();
+        return INJECTOR.getInstance(SQLImageMapper.class);
     }
 
     public static StoreRepository getStoreRepository()

--- a/src/test/java/tech/blacksource/blacknectar/service/data/SQLImageMapperTest.java
+++ b/src/test/java/tech/blacksource/blacknectar/service/data/SQLImageMapperTest.java
@@ -26,6 +26,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import tech.blacksource.blacknectar.service.images.Image;
 import tech.sirwellington.alchemy.test.junit.runners.AlchemyTestRunner;
+import tech.sirwellington.alchemy.test.junit.runners.DontRepeat;
 import tech.sirwellington.alchemy.test.junit.runners.Repeat;
 
 import static org.hamcrest.Matchers.is;
@@ -36,6 +37,7 @@ import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.when;
 import static tech.blacksource.blacknectar.service.BlackNectarGenerators.images;
 import static tech.sirwellington.alchemy.generator.AlchemyGenerator.one;
+import static tech.sirwellington.alchemy.test.junit.ThrowableAssertion.assertThrows;
 
 /**
  *
@@ -85,6 +87,13 @@ public class SQLImageMapperTest
         when(metadata.getColumnLabel(anyInt())).thenReturn(SQLColumns.Images.IMAGE_BINARY);
         
         when(sqlTools.hasColumn(results, SQLColumns.Images.IMAGE_BINARY)).thenReturn(true);
+    }
+    
+    @DontRepeat
+    @Test
+    public void testConstructor() throws Exception
+    {
+        assertThrows(() -> new SQLImageMapper.Impl(null)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/src/test/java/tech/blacksource/blacknectar/service/data/SQLStoreMapperTest.java
+++ b/src/test/java/tech/blacksource/blacknectar/service/data/SQLStoreMapperTest.java
@@ -80,6 +80,13 @@ public class SQLStoreMapperTest
         when(sqlTools.hasColumn(results, SQLColumns.Images.URL))
             .thenReturn(true);
     }
+    
+    @DontRepeat
+    @Test
+    public void testConstructor() throws Exception
+    {
+        assertThrows(() -> new SQLStoreMapper.Impl(null)).isInstanceOf(IllegalArgumentException.class);
+    }
 
     @Test
     public void testMapToStore() throws Exception

--- a/src/test/java/tech/blacksource/blacknectar/service/data/SQLStoreMapperTest.java
+++ b/src/test/java/tech/blacksource/blacknectar/service/data/SQLStoreMapperTest.java
@@ -100,7 +100,7 @@ public class SQLStoreMapperTest
     }
 
     @Test
-    public void testMapToStoreWithoutImageLink() throws Exception
+    public void testMapToStoreWhenStoreHasNoImage() throws Exception
     {
         when(sqlTools.hasColumn(results, SQLColumns.Images.URL))
             .thenReturn(false);
@@ -130,6 +130,20 @@ public class SQLStoreMapperTest
         when(results.getDouble(SQLColumns.LATITUDE)).thenReturn(store.getLocation().getLatitude());
         when(results.getDouble(SQLColumns.LONGITUDE)).thenReturn(store.getLocation().getLongitude());
         when(results.getString(SQLColumns.Images.URL)).thenReturn(store.getMainImageURL());
+    }
+
+    @Test
+    public void testMapRow() throws Exception
+    {
+    }
+
+    public class SQLStoreMapperImpl implements SQLStoreMapper
+    {
+
+        public Store mapRow(ResultSet results, int rowNum) throws SQLException
+        {
+            return null;
+        }
     }
 
 }

--- a/src/test/java/tech/blacksource/blacknectar/service/data/SQLStoreMapperTest.java
+++ b/src/test/java/tech/blacksource/blacknectar/service/data/SQLStoreMapperTest.java
@@ -37,42 +37,48 @@ import static tech.blacksource.blacknectar.service.BlackNectarGenerators.stores;
 import static tech.sirwellington.alchemy.generator.CollectionGenerators.listOf;
 import static tech.sirwellington.alchemy.test.junit.ThrowableAssertion.assertThrows;
 
-
 /**
  *
  * @author SirWellington
  */
 @Repeat(50)
 @RunWith(AlchemyTestRunner.class)
-public class SQLStoreMapperTest 
+public class SQLStoreMapperTest
 {
+
     private SQLStoreMapper instance;
 
     private List<Store> stores;
     private Store store;
-    
+    private Store storeWithoutImage;
+
     @Mock
     private ResultSet results;
-    
+
+    @Mock
+    private SQLTools sqlTools;
+
     @Before
     public void setUp() throws Exception
     {
-        
         setupData();
         setupMocks();
-        instance = SQLStoreMapper.INSTANCE;
-    }
 
+        instance = new SQLStoreMapper.Impl(sqlTools);
+    }
 
     private void setupData() throws Exception
     {
         stores = listOf(stores());
         store = oneOf(stores);
+        storeWithoutImage = Store.Builder.fromStore(store).withoutMainImageURL().build();
     }
 
     private void setupMocks() throws Exception
     {
         setupResultsWithStore(results, store);
+        when(sqlTools.hasColumn(results, SQLColumns.Images.URL))
+            .thenReturn(true);
     }
 
     @Test
@@ -81,7 +87,7 @@ public class SQLStoreMapperTest
         Store result = instance.mapRow(results, 1);
         assertThat(result, is(store));
     }
-    
+
     @Test
     public void testMapToStoreWithMultipleResults() throws Exception
     {
@@ -93,13 +99,23 @@ public class SQLStoreMapperTest
         }
     }
 
+    @Test
+    public void testMapToStoreWithoutImageLink() throws Exception
+    {
+        when(sqlTools.hasColumn(results, SQLColumns.Images.URL))
+            .thenReturn(false);
+        
+        Store result = instance.mapRow(results, 1);
+        assertThat(result, is(storeWithoutImage));
+    }
+
     @DontRepeat
     @Test
     public void testMapToStoreWithBadArguments() throws Exception
     {
         assertThrows(() -> instance.mapRow(null, 1)).isInstanceOf(IllegalArgumentException.class);
     }
-    
+
     private void setupResultsWithStore(ResultSet results, Store store) throws SQLException
     {
         when(results.getObject(SQLColumns.STORE_ID, UUID.class)).thenReturn(UUID.fromString(store.getStoreId()));
@@ -113,6 +129,7 @@ public class SQLStoreMapperTest
         when(results.getString(SQLColumns.LOCAL_ZIP_CODE)).thenReturn(store.getAddress().getLocalZipCode());
         when(results.getDouble(SQLColumns.LATITUDE)).thenReturn(store.getLocation().getLatitude());
         when(results.getDouble(SQLColumns.LONGITUDE)).thenReturn(store.getLocation().getLongitude());
+        when(results.getString(SQLColumns.Images.URL)).thenReturn(store.getMainImageURL());
     }
 
 }

--- a/src/test/java/tech/blacksource/blacknectar/service/data/SQLStoreRepositoryIT.java
+++ b/src/test/java/tech/blacksource/blacknectar/service/data/SQLStoreRepositoryIT.java
@@ -69,9 +69,9 @@ public class SQLStoreRepositoryIT
     @Before
     public void setUp() throws Exception
     {
-        
         setupData();
         setupMocks();
+        
         instance = new SQLStoreRepository(aroma, database, storeMapper);
     }
 
@@ -87,7 +87,6 @@ public class SQLStoreRepositoryIT
         aroma = TestingResources.getAroma();
         database = TestingResources.createDatabaseConnection();
         storeMapper = SQLStoreMapper.INSTANCE;
-        
     }
 
     @Test

--- a/src/test/java/tech/blacksource/blacknectar/service/data/SQLToolsTest.java
+++ b/src/test/java/tech/blacksource/blacknectar/service/data/SQLToolsTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017 BlackSource, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tech.blacksource.blacknectar.service.data;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import tech.sirwellington.alchemy.test.junit.runners.AlchemyTestRunner;
+import tech.sirwellington.alchemy.test.junit.runners.DontRepeat;
+import tech.sirwellington.alchemy.test.junit.runners.GenerateInteger;
+import tech.sirwellington.alchemy.test.junit.runners.GenerateString;
+import tech.sirwellington.alchemy.test.junit.runners.Repeat;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.when;
+import static tech.sirwellington.alchemy.generator.AlchemyGenerator.one;
+import static tech.sirwellington.alchemy.generator.StringGenerators.alphabeticString;
+import static tech.sirwellington.alchemy.test.junit.ThrowableAssertion.assertThrows;
+import static tech.sirwellington.alchemy.test.junit.runners.GenerateInteger.Type.RANGE;
+
+
+/**
+ *
+ * @author SirWellington
+ */
+@Repeat(10)
+@RunWith(AlchemyTestRunner.class)
+public class SQLToolsTest 
+{
+    
+    @Mock
+    private ResultSet results;
+    
+    @Mock
+    private ResultSetMetaData metaData;
+    
+    private SQLTools instance;
+    
+    @GenerateInteger(value = RANGE, min = 1, max = 20)
+    private int numberOfColumns;
+    
+    @GenerateString
+    private String columnName;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        
+        setupData();
+        setupMocks();
+        
+        instance = new SQLTools.Impl();
+    }
+
+
+    private void setupData() throws Exception
+    {
+        
+    }
+
+    private void setupMocks() throws Exception
+    {
+        when(results.getMetaData()).thenReturn(metaData);
+        when(metaData.getColumnCount()).thenReturn(numberOfColumns);
+        
+        when(metaData.getColumnLabel(anyInt())).thenReturn(one(alphabeticString()));
+    }
+
+    @Test
+    public void testHasColumnWhenHasColumn() throws Exception
+    {
+        when(metaData.getColumnLabel(1)).thenReturn(columnName);
+        
+        boolean result = instance.hasColumn(results, columnName);
+        assertTrue(result);
+    }
+    
+    @Test
+    public void testHasColumnWhenNotPresent() throws Exception
+    {
+        boolean result = instance.hasColumn(results, columnName);
+        assertFalse(result);
+    }
+    
+    @DontRepeat
+    @Test
+    public void testHasColumnWithBadArgs() throws Exception
+    {
+        assertThrows(() -> instance.hasColumn(null, columnName)).isInstanceOf(IllegalArgumentException.class);
+        assertThrows(() -> instance.hasColumn(results, "")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+}


### PR DESCRIPTION
This PR addresses #38.
Basically it makes it so that images are obtained for stores at the same time as the query.

This reduces load on the database and also improves performance, as the database doesn't need to be hit again for each store.